### PR TITLE
Pass to plan_fft all optional keywords of NFFTPlan

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -13,7 +13,7 @@ sigma = 2.0
 
             M = prod(N)
             x = rand(D,M) - 0.5
-            p = NFFTPlan(x, N, m, sigma, window)
+            p = NFFTPlan(x, N, m, sigma, window, flags = FFTW.ESTIMATE)
 
             fHat = rand(M) + rand(M)*im
             f = ndft_adjoint(p, fHat)
@@ -34,7 +34,7 @@ end
 @testset "Abstract sampling points" begin
     M, N = rand(100:200, 2)
     x = linspace(-0.4, 0.4, M)
-    p = NFFTPlan(x, N)
+    p = NFFTPlan(x, N, flags = FFTW.MEASURE)
 end
 
 @testset "Directional NFFT $D dim" for D in 2:3 begin


### PR DESCRIPTION
As suggested in #19, this patch allows setting in `NFFTPlan` optional keywords to be passed to `plan_fft`.

Actually, there isn't a large overall speed-up in `nfft` and `nfft_adjoint` passing from `flags = FFTW.ESTIMATE` (the default) to `flags =FFTW.MEASURE`, but according to profile the computation of the Fourier transforms isn't the most time-consuming task (which instead is convolution).