### PR TITLE
More coherent indentation style

### DIFF
--- a/src/NFFT.jl
+++ b/src/NFFT.jl
@@ -36,24 +36,24 @@ DIM is a type parameter since it allows the @generated macro to
 compile more efficient methods.
 =#
 type NFFTPlan{D,DIM,T}
-  N::NTuple{D,Int64}
-  M::Int64
-  x::Matrix{T}
-  m::Int64
-  sigma::T
-  n::NTuple{D,Int64}
-  K::Int64
-  windowLUT::Vector{Vector{T}}
-  windowHatInvLUT::Vector{Vector{T}}
-  forwardFFT::Base.DFT.FFTW.cFFTWPlan{Complex{Float64},-1,true,D}
-  backwardFFT::Base.DFT.FFTW.cFFTWPlan{Complex{Float64},1,true,D}
-  tmpVec::Array{Complex{T},D}
+    N::NTuple{D,Int64}
+    M::Int64
+    x::Matrix{T}
+    m::Int64
+    sigma::T
+    n::NTuple{D,Int64}
+    K::Int64
+    windowLUT::Vector{Vector{T}}
+    windowHatInvLUT::Vector{Vector{T}}
+    forwardFFT::Base.DFT.FFTW.cFFTWPlan{Complex{Float64},-1,true,D}
+    backwardFFT::Base.DFT.FFTW.cFFTWPlan{Complex{Float64},1,true,D}
+    tmpVec::Array{Complex{T},D}
 end
 
 @inline dim{D,DIM}(::NFFTPlan{D,DIM}) = DIM
 
 """
-	NFFTPlan(x, N, ...) -> plan
+        NFFTPlan(x, N, ...) -> plan
 
 Compute `D` dimensional NFFT plan for sampling locations `x` (a vector or a `D`-by-`M` matrix) that can be applied on arrays of size `N` (a tuple of length `D`).
 
@@ -64,56 +64,56 @@ It takes as optional keywords all the keywords supported by `plan_fft` function 
 """
 function NFFTPlan{D,T}(x::AbstractMatrix{T}, N::NTuple{D,Int}, m=4, sigma=2.0,
                        window=:kaiser_bessel, K=2000; kwargs...)
-  if !isa(x, Matrix)
-	  x = collect(x)
-  end
-
-  if D != size(x,1)
-    throw(ArgumentError())
-  end
-
-  n = ntuple(d->round(Int,sigma*N[d]), D)
-
-  tmpVec = zeros(Complex{T}, n)
-
-  M = size(x,2)
-
-  FP = plan_fft!(tmpVec; kwargs...)
-  BP = plan_bfft!(tmpVec; kwargs...)
-
-  # Create lookup table
-  win, win_hat = getWindow(window)
-
-  windowLUT = Vector{Vector{T}}(D)
-  Z = round(Int,3*K/2)
-  for d=1:D
-    windowLUT[d] = zeros(T, Z)
-    for l=1:Z
-      y = ((l-1) / (K-1)) * m/n[d]
-      windowLUT[d][l] = win(y, n[d], m, sigma)
+    if !isa(x, Matrix)
+        x = collect(x)
     end
-  end
 
-  windowHatInvLUT = Vector{Vector{T}}(D)
-  for d=1:D
-    windowHatInvLUT[d] = zeros(T, N[d])
-    for k=1:N[d]
-      windowHatInvLUT[d][k] = 1. / win_hat(k-1-N[d]/2, n[d], m, sigma)
+    if D != size(x,1)
+        throw(ArgumentError())
     end
-  end
 
-  NFFTPlan{D,0,T}(N, M, x, m, sigma, n, K, windowLUT, windowHatInvLUT, FP, BP, tmpVec )
+    n = ntuple(d->round(Int,sigma*N[d]), D)
+
+    tmpVec = zeros(Complex{T}, n)
+
+    M = size(x,2)
+
+    FP = plan_fft!(tmpVec; kwargs...)
+    BP = plan_bfft!(tmpVec; kwargs...)
+
+    # Create lookup table
+    win, win_hat = getWindow(window)
+
+    windowLUT = Vector{Vector{T}}(D)
+    Z = round(Int,3*K/2)
+    for d=1:D
+        windowLUT[d] = zeros(T, Z)
+        for l=1:Z
+            y = ((l-1) / (K-1)) * m/n[d]
+            windowLUT[d][l] = win(y, n[d], m, sigma)
+        end
+    end
+
+    windowHatInvLUT = Vector{Vector{T}}(D)
+    for d=1:D
+        windowHatInvLUT[d] = zeros(T, N[d])
+        for k=1:N[d]
+            windowHatInvLUT[d][k] = 1. / win_hat(k-1-N[d]/2, n[d], m, sigma)
+        end
+    end
+
+    NFFTPlan{D,0,T}(N, M, x, m, sigma, n, K, windowLUT, windowHatInvLUT, FP, BP, tmpVec )
 end
 
 function NFFTPlan(x::AbstractVector, N::Integer, m=4, sigma=2.0, window=:kaiser_bessel,
                   K=2000; kwargs...)
-  NFFTPlan(reshape(x,1,length(x)), (N,), m, sigma, window, K; kwargs...)
+    NFFTPlan(reshape(x,1,length(x)), (N,), m, sigma, window, K; kwargs...)
 end
 
 
 # Directional NFFT
 """
-	NFFTPlan(x, d, N, ...) -> plan
+        NFFTPlan(x, d, N, ...) -> plan
 
 Compute *directional* NFFT plan:
 A 1D plan that is applied along dimension `d` of a `D` dimensional array of size `N` with sampling locations `x` (a vector).
@@ -123,96 +123,96 @@ It takes as optional keywords all the keywords supported by `plan_fft` function 
 """
 function NFFTPlan{D,T}(x::AbstractVector{T}, dim::Integer, N::NTuple{D,Int64}, m=4,
                        sigma=2.0, window=:kaiser_bessel, K=2000; kwargs...)
-  n = ntuple(d->round(Int, sigma*N[d]), D)
+    n = ntuple(d->round(Int, sigma*N[d]), D)
 
-  sz = [N...]
-  sz[dim] = n[dim]
-  tmpVec = Array{Complex{T}}(sz...)
+    sz = [N...]
+    sz[dim] = n[dim]
+    tmpVec = Array{Complex{T}}(sz...)
 
-  M = length(x)
+    M = length(x)
 
-  FP = plan_fft!(tmpVec, dim; kwargs...)
-  BP = plan_bfft!(tmpVec, dim; kwargs...)
+    FP = plan_fft!(tmpVec, dim; kwargs...)
+    BP = plan_bfft!(tmpVec, dim; kwargs...)
 
-  # Create lookup table
-  win, win_hat = getWindow(window)
+    # Create lookup table
+    win, win_hat = getWindow(window)
 
-  windowLUT = Vector{Vector{T}}(1)
-  Z = round(Int, 3*K/2)
-  windowLUT[1] = zeros(T, Z)
-  for l = 1:Z
-	  y = ((l-1) / (K-1)) * m/n[dim]
-	  windowLUT[1][l] = win(y, n[dim], m, sigma)
-  end
+    windowLUT = Vector{Vector{T}}(1)
+    Z = round(Int, 3*K/2)
+    windowLUT[1] = zeros(T, Z)
+    for l = 1:Z
+        y = ((l-1) / (K-1)) * m/n[dim]
+        windowLUT[1][l] = win(y, n[dim], m, sigma)
+    end
 
-  windowHatInvLUT = Vector{Vector{T}}(1)
-  windowHatInvLUT[1] = zeros(T, N[dim])
-  for k = 1:N[dim]
-	  windowHatInvLUT[1][k] = 1. / win_hat(k-1-N[dim]/2, n[dim], m, sigma)
-  end
+    windowHatInvLUT = Vector{Vector{T}}(1)
+    windowHatInvLUT[1] = zeros(T, N[dim])
+    for k = 1:N[dim]
+        windowHatInvLUT[1][k] = 1. / win_hat(k-1-N[dim]/2, n[dim], m, sigma)
+    end
 
-  NFFTPlan{D,dim,T}(N, M, reshape(x,1,M), m, sigma, n, K, windowLUT, windowHatInvLUT, FP, BP, tmpVec)
+    NFFTPlan{D,dim,T}(N, M, reshape(x,1,M), m, sigma, n, K, windowLUT, windowHatInvLUT, FP, BP, tmpVec)
 end
 
 function NFFTPlan{D,T}(x::Matrix{T}, dim::Integer, N::NTuple{D,Int}, m=4, sigma=2.0,
                        window=:kaiser_bessel, K=2000; kwargs...)
-  if size(x,1) != 1 && size(x,2) != 1
-	  throw(DimensionMismatch())
-  end
+    if size(x,1) != 1 && size(x,2) != 1
+        throw(DimensionMismatch())
+    end
 
-  NFFTPlan(vec(x), dim, N, m, sigma, window, K; kwargs...)
+    NFFTPlan(vec(x), dim, N, m, sigma, window, K; kwargs...)
 end
 
 
 function Base.show{D}(io::IO, p::NFFTPlan{D,0})
-	print(io, "NFFTPlan with ", p.M, " sampling points for ", p.N, " array")
+    print(io, "NFFTPlan with ", p.M, " sampling points for ", p.N, " array")
 end
 
 function Base.show{D,DIM}(io::IO, p::NFFTPlan{D,DIM})
-	print(io, "NFFTPlan with ", p.M, " sampling points for ", p.N, " array along dimension ", DIM)
+    print(io, "NFFTPlan with ", p.M, " sampling points for ", p.N, " array along dimension ", DIM)
 end
 
 
 @generated function consistencyCheck{D,DIM,T}(p::NFFTPlan{D,DIM}, f::AbstractArray{T,D}, fHat::AbstractArray{T})
-	quote
+    quote
         if $DIM == 0
             fHat_test = (p.M == length(fHat))
         elseif $DIM > 0
             fHat_test = @nall $D d -> ( d == $DIM ? size(fHat,d) == p.M : size(fHat,d) == p.N[d] )
         end
 
-		if p.N != size(f) || !fHat_test
-			throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
-		end
-	end
+        if p.N != size(f) || !fHat_test
+            throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
+        end
+    end
 end
 
 
 ### nfft functions ###
 
 """
-	nfft!(p, f, fHat) -> fHat
+        nfft!(p, f, fHat) -> fHat
 
 Calculate the NFFT of `f` with plan `p` and store the result in `fHat`.
 
 Both `f` and `fHat` must be complex arrays.
 """
 function nfft!{T}(p::NFFTPlan, f::AbstractArray{T}, fHat::StridedArray{T})
-  consistencyCheck(p, f, fHat)
+    consistencyCheck(p, f, fHat)
 
-  fill!(p.tmpVec, zero(T))
-  @inbounds apodization!(p, f, p.tmpVec)
-  if nprocs() == 1
-    p.forwardFFT * p.tmpVec # fft!(p.tmpVec) or fft!(p.tmpVec, dim)
-  else
-    dim(p) == 0 ? fft!(p.tmpVec) : fft!(p.tmpVec, dim(p))
-  end
-  @inbounds convolve!(p, p.tmpVec, fHat)
-  return fHat
+    fill!(p.tmpVec, zero(T))
+    @inbounds apodization!(p, f, p.tmpVec)
+    if nprocs() == 1
+        p.forwardFFT * p.tmpVec # fft!(p.tmpVec) or fft!(p.tmpVec, dim)
+    else
+        dim(p) == 0 ? fft!(p.tmpVec) : fft!(p.tmpVec, dim(p))
+    end
+    @inbounds convolve!(p, p.tmpVec, fHat)
+    return fHat
 end
 
 """
-	nfft(p, f) -> fHat
+        nfft(p, f) -> fHat
 
 For a **non**-directional `D` dimensional plan `p` this calculates the NFFT of a `D` dimensional array `f` of size `N`.
 `fHat` is a vector of length `M`.
@@ -223,47 +223,47 @@ dimensional arrays, and the dimension specified in the plan creation is
 affected.
 """
 function nfft{D,T}(p::NFFTPlan{D,0}, f::AbstractArray{T,D})
-  fHat = zeros(T, p.M)
-  nfft!(p, f, fHat)
-  return fHat
+    fHat = zeros(T, p.M)
+    nfft!(p, f, fHat)
+    return fHat
 end
 
 function nfft{D,T}(x, f::AbstractArray{T,D}, rest...; kwargs...)
-  p = NFFTPlan(x, size(f), rest...; kwargs...)
-  return nfft(p, f)
+    p = NFFTPlan(x, size(f), rest...; kwargs...)
+    return nfft(p, f)
 end
 
 function nfft{D,DIM,T}(p::NFFTPlan{D,DIM}, f::AbstractArray{T,D})
-  sz = [p.N...]
-  sz[DIM] = p.M
-  fHat = Array{T}(sz...)
-  nfft!(p, f, fHat)
-  return fHat
+    sz = [p.N...]
+    sz[DIM] = p.M
+    fHat = Array{T}(sz...)
+    nfft!(p, f, fHat)
+    return fHat
 end
 
 
 """
-	nfft_adjoint!(p, fHat, f) -> f
+        nfft_adjoint!(p, fHat, f) -> f
 
 Calculate the adjoint NFFT of `fHat` and store the result in `f`.
 
 Both `f` and `fHat` must be complex arrays.
 """
 function nfft_adjoint!(p::NFFTPlan, fHat::AbstractArray, f::StridedArray)
-  consistencyCheck(p, f, fHat)
+    consistencyCheck(p, f, fHat)
 
-  @inbounds convolve_adjoint!(p, fHat, p.tmpVec)
-  if nprocs() == 1
-    p.backwardFFT * p.tmpVec # bfft!(p.tmpVec) or bfft!(p.tmpVec, dim)
-  else
-    dim(p) == 0 ? bfft!(p.tmpVec) : bfft!(p.tmpVec, dim(p))
-  end
-  @inbounds apodization_adjoint!(p, p.tmpVec, f)
-  return f
+    @inbounds convolve_adjoint!(p, fHat, p.tmpVec)
+    if nprocs() == 1
+        p.backwardFFT * p.tmpVec # bfft!(p.tmpVec) or bfft!(p.tmpVec, dim)
+    else
+        dim(p) == 0 ? bfft!(p.tmpVec) : bfft!(p.tmpVec, dim(p))
+    end
+    @inbounds apodization_adjoint!(p, p.tmpVec, f)
+    return f
 end
 
 """
-	nfft_adjoint(p, f) -> fHat
+        nfft_adjoint(p, f) -> fHat
 
 For a **non**-directional `D` dimensional plan `p` this calculates the adjoint NFFT of a length `M` vector `fHat`
 `f` is a `D` dimensional array of size `N`.
@@ -274,14 +274,14 @@ dimensional arrays, and the dimension specified in the plan creation is
 affected.
 """
 function nfft_adjoint{D,DIM,T}(p::NFFTPlan{D,DIM}, fHat::AbstractArray{T})
-  f = Array{T}(p.N)
-  nfft_adjoint!(p, fHat, f)
-  return f
+    f = Array{T}(p.N)
+    nfft_adjoint!(p, fHat, f)
+    return f
 end
 
 function nfft_adjoint{T}(x, N, fHat::AbstractVector{T}, rest...; kwargs...)
-  p = NFFTPlan(x, N, rest...; kwargs...)
-  return nfft_adjoint(p, fHat)
+    p = NFFTPlan(x, N, rest...; kwargs...)
+    return nfft_adjoint(p, fHat)
 end
 
 
@@ -289,47 +289,47 @@ end
 
 # fallback for 1D
 function ind2sub{T}(::Array{T,1}, idx::Int)
-  idx
+    idx
 end
 
 function ndft{T,D}(plan::NFFTPlan{D}, f::AbstractArray{T,D})
-  plan.N == size(f) || throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
+    plan.N == size(f) || throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
 
-  g = zeros(T, plan.M)
+    g = zeros(T, plan.M)
 
-  for l=1:prod(plan.N)
-    idx = ind2sub(plan.N,l)
+    for l=1:prod(plan.N)
+        idx = ind2sub(plan.N,l)
 
-    for k=1:plan.M
-      arg = zero(T)
-      for d=1:D
-        arg += plan.x[d,k] * ( idx[d] - 1 - plan.N[d] / 2 )
-      end
-      g[k] += f[l] * cis(-2*pi*arg)
+        for k=1:plan.M
+            arg = zero(T)
+            for d=1:D
+                arg += plan.x[d,k] * ( idx[d] - 1 - plan.N[d] / 2 )
+            end
+            g[k] += f[l] * cis(-2*pi*arg)
+        end
     end
-  end
 
-  return g
+    return g
 end
 
 function ndft_adjoint{T,D}(plan::NFFTPlan{D}, fHat::AbstractArray{T,1})
-  plan.M == length(fHat) || throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
+    plan.M == length(fHat) || throw(DimensionMismatch("Data is not consistent with NFFTPlan"))
 
-  g = zeros(T, plan.N)
+    g = zeros(T, plan.N)
 
-  for l=1:prod(plan.N)
-    idx = ind2sub(plan.N,l)
+    for l=1:prod(plan.N)
+        idx = ind2sub(plan.N,l)
 
-    for k=1:plan.M
-      arg = zero(T)
-      for d=1:D
-        arg += plan.x[d,k] * ( idx[d] - 1 - plan.N[d] / 2 )
-      end
-      g[l] += fHat[k] * cis(2*pi*arg)
+        for k=1:plan.M
+            arg = zero(T)
+            for d=1:D
+                arg += plan.x[d,k] * ( idx[d] - 1 - plan.N[d] / 2 )
+            end
+            g[l] += fHat[k] * cis(2*pi*arg)
+        end
     end
-  end
 
-  return g
+    return g
 end
 
 
@@ -337,20 +337,20 @@ end
 ### convolve! ###
 
 function convolve!{T}(p::NFFTPlan{1,0}, g::AbstractVector{T}, fHat::StridedVector{T})
-  fill!(fHat, zero(T))
-  scale = 1.0 / p.m * (p.K-1)
-  n = p.n[1]
+    fill!(fHat, zero(T))
+    scale = 1.0 / p.m * (p.K-1)
+    n = p.n[1]
 
-  for k=1:p.M # loop over nonequispaced nodes
-    c = floor(Int, p.x[k]*n)
-    for l=(c-p.m):(c+p.m) # loop over nonzero elements
-      gidx = rem(l+n, n) + 1
-      idx = abs( (p.x[k]*n - l)*scale ) + 1
-      idxL = floor(Int, idx)
+    for k=1:p.M # loop over nonequispaced nodes
+        c = floor(Int, p.x[k]*n)
+        for l=(c-p.m):(c+p.m) # loop over nonzero elements
+            gidx = rem(l+n, n) + 1
+            idx = abs( (p.x[k]*n - l)*scale ) + 1
+            idxL = floor(Int, idx)
 
-      fHat[k] += g[gidx] * (p.windowLUT[1][idxL] + ( idx-idxL ) * (p.windowLUT[1][idxL+1] - p.windowLUT[1][idxL]))
+            fHat[k] += g[gidx] * (p.windowLUT[1][idxL] + ( idx-idxL ) * (p.windowLUT[1][idxL+1] - p.windowLUT[1][idxL]))
+        end
     end
-  end
 end
 
 function convolve!{D,T}(p::NFFTPlan{D,0}, g::AbstractArray{T,D}, fHat::StridedVector{T})
@@ -363,7 +363,7 @@ end
 
 
 @generated function _convolve{D,T}(p::NFFTPlan{D,0}, g::AbstractArray{T,D}, scale, k)
-	quote
+    quote
         @nexprs $D d -> xscale_d = p.x[d,k] * p.n[d]
         @nexprs $D d -> c_d = floor(Int, xscale_d)
 
@@ -388,207 +388,207 @@ end
 end
 
 @generated function convolve!{D,DIM,T}(p::NFFTPlan{D,DIM}, g::AbstractArray{T,D}, fHat::StridedArray{T,D})
-	quote
-		fill!(fHat, zero(T))
-		scale = 1.0 / p.m * (p.K-1)
+    quote
+        fill!(fHat, zero(T))
+        scale = 1.0 / p.m * (p.K-1)
 
-		for k in 1:p.M
-			xscale = p.x[k] * p.n[$DIM]
-			c = floor(Int, xscale)
-			@nloops $D l d->begin
-				# rangeexpr
-				if d == $DIM
-					(c-p.m):(c+p.m)
-				else
-					1:size(g,d)
-				end
-			end d->begin
-				# preexpr
-				if d == $DIM
-					gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
-					idx = abs( (xscale - l_d)*scale ) + 1
-					idxL = floor(idx)
-					idxInt = Int(idxL)
-					tmpWin = p.windowLUT[1][idxInt] + ( idx-idxL ) * (p.windowLUT[1][idxInt+1] - p.windowLUT[1][idxInt])
-					fidx_d = k
-				else
-					gidx_d = l_d
-					fidx_d = l_d
-				end
-			end begin
-				# bodyexpr
-				(@nref $D fHat fidx) += (@nref $D g gidx) * tmpWin
-			end
-		end
-	end
+        for k in 1:p.M
+            xscale = p.x[k] * p.n[$DIM]
+            c = floor(Int, xscale)
+            @nloops $D l d->begin
+                # rangeexpr
+                if d == $DIM
+                    (c-p.m):(c+p.m)
+                else
+                    1:size(g,d)
+                end
+            end d->begin
+                # preexpr
+                if d == $DIM
+                    gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
+                    idx = abs( (xscale - l_d)*scale ) + 1
+                    idxL = floor(idx)
+                    idxInt = Int(idxL)
+                    tmpWin = p.windowLUT[1][idxInt] + ( idx-idxL ) * (p.windowLUT[1][idxInt+1] - p.windowLUT[1][idxInt])
+                    fidx_d = k
+                else
+                    gidx_d = l_d
+                    fidx_d = l_d
+                end
+            end begin
+                # bodyexpr
+                (@nref $D fHat fidx) += (@nref $D g gidx) * tmpWin
+            end
+        end
+    end
 end
 
 
 ### convolve_adjoint! ###
 
 function convolve_adjoint!{T}(p::NFFTPlan{1,0}, fHat::AbstractVector{T}, g::StridedVector{T})
-  fill!(g, zero(T))
-  scale = 1.0 / p.m * (p.K-1)
-  n = p.n[1]
+    fill!(g, zero(T))
+    scale = 1.0 / p.m * (p.K-1)
+    n = p.n[1]
 
-  for k=1:p.M # loop over nonequispaced nodes
-    c = round(Int,p.x[k]*n)
-    for l=(c-p.m):(c+p.m) # loop over nonzero elements
-      gidx = rem(l+n, n) + 1
-      idx = abs( (p.x[k]*n - l)*scale ) + 1
-      idxL = round(Int, idx)
+    for k=1:p.M # loop over nonequispaced nodes
+        c = round(Int,p.x[k]*n)
+        for l=(c-p.m):(c+p.m) # loop over nonzero elements
+            gidx = rem(l+n, n) + 1
+            idx = abs( (p.x[k]*n - l)*scale ) + 1
+            idxL = round(Int, idx)
 
-      g[gidx] += fHat[k] * (p.windowLUT[1][idxL] + ( idx-idxL ) * (p.windowLUT[1][idxL+1] - p.windowLUT[1][idxL]))
+            g[gidx] += fHat[k] * (p.windowLUT[1][idxL] + ( idx-idxL ) * (p.windowLUT[1][idxL+1] - p.windowLUT[1][idxL]))
+        end
     end
-  end
 end
 
 @generated function convolve_adjoint!{D,T}(p::NFFTPlan{D,0}, fHat::AbstractVector{T}, g::StridedArray{T,D})
-	quote
-		fill!(g, zero(T))
-		scale = 1.0 / p.m * (p.K-1)
+    quote
+        fill!(g, zero(T))
+        scale = 1.0 / p.m * (p.K-1)
 
-		for k in 1:p.M
-			@nexprs $D d -> xscale_d = p.x[d,k] * p.n[d]
-			@nexprs $D d -> c_d = floor(Int, xscale_d)
+        for k in 1:p.M
+            @nexprs $D d -> xscale_d = p.x[d,k] * p.n[d]
+            @nexprs $D d -> c_d = floor(Int, xscale_d)
 
-			@nloops $D l d -> (c_d-p.m):(c_d+p.m) d->begin
-				# preexpr
-				gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
-				idx = abs( (xscale_d - l_d)*scale ) + 1
-				idxL = floor(idx)
-				idxInt = Int(idxL)
-				tmpWin_d = p.windowLUT[d][idxInt] + ( idx-idxL ) * (p.windowLUT[d][idxInt+1] - p.windowLUT[d][idxInt])
-			end begin
-				# bodyexpr
-				v = fHat[k]
-				@nexprs $D d -> v *= tmpWin_d
-				(@nref $D g gidx) += v
-			end
-		end
-	end
+            @nloops $D l d -> (c_d-p.m):(c_d+p.m) d->begin
+                # preexpr
+                gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
+                idx = abs( (xscale_d - l_d)*scale ) + 1
+                idxL = floor(idx)
+                idxInt = Int(idxL)
+                tmpWin_d = p.windowLUT[d][idxInt] + ( idx-idxL ) * (p.windowLUT[d][idxInt+1] - p.windowLUT[d][idxInt])
+            end begin
+                # bodyexpr
+                v = fHat[k]
+                @nexprs $D d -> v *= tmpWin_d
+                (@nref $D g gidx) += v
+            end
+        end
+    end
 end
 
 @generated function convolve_adjoint!{D,DIM,T}(p::NFFTPlan{D,DIM}, fHat::AbstractArray{T,D}, g::StridedArray{T,D})
-	quote
-		fill!(g, zero(T))
-		scale = 1.0 / p.m * (p.K-1)
+    quote
+        fill!(g, zero(T))
+        scale = 1.0 / p.m * (p.K-1)
 
-		for k in 1:p.M
-			xscale = p.x[k] * p.n[$DIM]
-			c = floor(Int, xscale)
-			@nloops $D l d->begin
-				# rangeexpr
-				if d == $DIM
-					(c-p.m):(c+p.m)
-				else
-					1:size(g,d)
-				end
-			end d->begin
-				# preexpr
-				if d == $DIM
-					gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
-					idx = abs( (xscale - l_d)*scale ) + 1
-					idxL = floor(idx)
-					idxInt = Int(idxL)
-					tmpWin = p.windowLUT[1][idxInt] + ( idx-idxL ) * (p.windowLUT[1][idxInt+1] - p.windowLUT[1][idxInt])
-					fidx_d = k
-				else
-					gidx_d = l_d
-					fidx_d = l_d
-				end
-			end begin
-				# bodyexpr
-				(@nref $D g gidx) += (@nref $D fHat fidx) * tmpWin
-			end
-		end
-	end
+        for k in 1:p.M
+            xscale = p.x[k] * p.n[$DIM]
+            c = floor(Int, xscale)
+            @nloops $D l d->begin
+                # rangeexpr
+                if d == $DIM
+                    (c-p.m):(c+p.m)
+                else
+                    1:size(g,d)
+                end
+            end d->begin
+                # preexpr
+                if d == $DIM
+                    gidx_d = rem(l_d+p.n[d], p.n[d]) + 1
+                    idx = abs( (xscale - l_d)*scale ) + 1
+                    idxL = floor(idx)
+                    idxInt = Int(idxL)
+                    tmpWin = p.windowLUT[1][idxInt] + ( idx-idxL ) * (p.windowLUT[1][idxInt+1] - p.windowLUT[1][idxInt])
+                    fidx_d = k
+                else
+                    gidx_d = l_d
+                    fidx_d = l_d
+                end
+            end begin
+                # bodyexpr
+                (@nref $D g gidx) += (@nref $D fHat fidx) * tmpWin
+            end
+        end
+    end
 end
 
 
 ### apodization! ###
 
 function apodization!{T}(p::NFFTPlan{1,0}, f::AbstractVector{T}, g::StridedVector{T})
-  n = p.n[1]
-  N = p.N[1]
-  const offset = round( Int, n - N / 2 ) - 1
-  for l=1:N
-    g[((l+offset)% n) + 1] = f[l] * p.windowHatInvLUT[1][l]
-  end
+    n = p.n[1]
+    N = p.N[1]
+    const offset = round( Int, n - N / 2 ) - 1
+    for l=1:N
+        g[((l+offset)% n) + 1] = f[l] * p.windowHatInvLUT[1][l]
+    end
 end
 
 @generated function apodization!{D,T}(p::NFFTPlan{D,0}, f::AbstractArray{T,D}, g::StridedArray{T,D})
-	quote
-		@nexprs $D d -> offset_d = round(Int, p.n[d] - p.N[d]/2) - 1
+    quote
+        @nexprs $D d -> offset_d = round(Int, p.n[d] - p.N[d]/2) - 1
 
-		@nloops $D l f d->(gidx_d = rem(l_d+offset_d, p.n[d]) + 1) begin
-			v = @nref $D f l
-			@nexprs $D d -> v *= p.windowHatInvLUT[d][l_d]
-			(@nref $D g gidx) = v
-		end
-	end
+        @nloops $D l f d->(gidx_d = rem(l_d+offset_d, p.n[d]) + 1) begin
+            v = @nref $D f l
+            @nexprs $D d -> v *= p.windowHatInvLUT[d][l_d]
+            (@nref $D g gidx) = v
+        end
+    end
 end
 
 @generated function apodization!{D,DIM,T}(p::NFFTPlan{D,DIM}, f::AbstractArray{T,D}, g::StridedArray{T,D})
-	quote
-		offset = round(Int, p.n[$DIM] - p.N[$DIM]/2) - 1
+    quote
+        offset = round(Int, p.n[$DIM] - p.N[$DIM]/2) - 1
 
-		@nloops $D l f d->begin
-			# preexpr
-			if d == $DIM
-				gidx_d = rem(l_d+offset, p.n[d]) + 1
-				winidx = l_d
-			else
-				gidx_d = l_d
-			end
-		end begin
-			# bodyexpr
-			(@nref $D g gidx) = (@nref $D f l) * p.windowHatInvLUT[1][winidx]
-		end
-	end
+        @nloops $D l f d->begin
+            # preexpr
+            if d == $DIM
+                gidx_d = rem(l_d+offset, p.n[d]) + 1
+                winidx = l_d
+            else
+                gidx_d = l_d
+            end
+        end begin
+            # bodyexpr
+            (@nref $D g gidx) = (@nref $D f l) * p.windowHatInvLUT[1][winidx]
+        end
+    end
 end
 
 
 ### apodization_adjoint! ###
 
 function apodization_adjoint!{T}(p::NFFTPlan{1,0}, g::AbstractVector{T}, f::StridedVector{T})
-  n = p.n[1]
-  N = p.N[1]
-  const offset = round( Int, n - N / 2 ) - 1
-  for l=1:N
-    f[l] = g[((l+offset)% n) + 1] * p.windowHatInvLUT[1][l]
-  end
+    n = p.n[1]
+    N = p.N[1]
+    const offset = round( Int, n - N / 2 ) - 1
+    for l=1:N
+        f[l] = g[((l+offset)% n) + 1] * p.windowHatInvLUT[1][l]
+    end
 end
 
 @generated function apodization_adjoint!{T,D}(p::NFFTPlan{D,0}, g::AbstractArray{T,D}, f::StridedArray{T,D})
-	quote
-		@nexprs $D d -> offset_d = round(Int, p.n[d] - p.N[d]/2) - 1
+    quote
+        @nexprs $D d -> offset_d = round(Int, p.n[d] - p.N[d]/2) - 1
 
-		@nloops $D l f begin
-			v = @nref $D g d -> rem(l_d+offset_d, p.n[d]) + 1
-			@nexprs $D d -> v *= p.windowHatInvLUT[d][l_d]
-			(@nref $D f l) = v
-		end
-	end
+        @nloops $D l f begin
+            v = @nref $D g d -> rem(l_d+offset_d, p.n[d]) + 1
+            @nexprs $D d -> v *= p.windowHatInvLUT[d][l_d]
+            (@nref $D f l) = v
+        end
+    end
 end
 
 @generated function apodization_adjoint!{D,DIM,T}(p::NFFTPlan{D,DIM}, g::AbstractArray{T,D}, f::StridedArray{T,D})
-	quote
-		offset = round(Int, p.n[$DIM] - p.N[$DIM]/2) - 1
+    quote
+        offset = round(Int, p.n[$DIM] - p.N[$DIM]/2) - 1
 
-		@nloops $D l f d->begin
-			# preexpr
-			if d == $DIM
-				gidx_d = rem(l_d+offset, p.n[d]) + 1
-				winidx = l_d
-			else
-				gidx_d = l_d
-			end
-		end begin
-			# bodyexpr
-			(@nref $D f l) = (@nref $D g gidx) * p.windowHatInvLUT[1][winidx]
-		end
-	end
+        @nloops $D l f d->begin
+            # preexpr
+            if d == $DIM
+                gidx_d = rem(l_d+offset, p.n[d]) + 1
+                winidx = l_d
+            else
+                gidx_d = l_d
+            end
+        end begin
+            # bodyexpr
+            (@nref $D f l) = (@nref $D g gidx) * p.windowHatInvLUT[1][winidx]
+        end
+    end
 end
 
 
@@ -596,79 +596,79 @@ end
 
 function nfft_performance()
 
-  m = 4
-  sigma = 2.0
+    m = 4
+    sigma = 2.0
 
-  # 1D
+    # 1D
 
-  N = 2^19
-  M = N
+    N = 2^19
+    M = N
 
-  x = rand(M) .- 0.5
-  fHat = rand(M)*1im
+    x = rand(M) .- 0.5
+    fHat = rand(M)*1im
 
-  println("NFFT Performance Test 1D")
+    println("NFFT Performance Test 1D")
 
-  tic()
-  p = NFFTPlan(x,N,m,sigma)
-  println("initialization")
-  toc()
+    tic()
+    p = NFFTPlan(x,N,m,sigma)
+    println("initialization")
+    toc()
 
-  tic()
-  fApprox = nfft_adjoint(p,fHat)
-  println("adjoint")
-  toc()
+    tic()
+    fApprox = nfft_adjoint(p,fHat)
+    println("adjoint")
+    toc()
 
-  tic()
-  fHat2 = nfft(p, fApprox);
-  println("trafo")
-  toc()
+    tic()
+    fHat2 = nfft(p, fApprox);
+    println("trafo")
+    toc()
 
-  N = 1024
-  M = N*N
+    N = 1024
+    M = N*N
 
-  x2 = rand(2,M) .- 0.5
-  fHat = rand(M)*1im
+    x2 = rand(2,M) .- 0.5
+    fHat = rand(M)*1im
 
-  println("NFFT Performance Test 2D")
+    println("NFFT Performance Test 2D")
 
-  tic()
-  p = NFFTPlan(x2,(N,N),m,sigma)
-  println("initialization")
-  toc()
+    tic()
+    p = NFFTPlan(x2,(N,N),m,sigma)
+    println("initialization")
+    toc()
 
-  tic()
-  fApprox = nfft_adjoint(p,fHat)
-  println("adjoint")
-  toc()
+    tic()
+    fApprox = nfft_adjoint(p,fHat)
+    println("adjoint")
+    toc()
 
-  tic()
-  fHat2 = nfft(p, fApprox);
-  println("trafo")
-  toc()
+    tic()
+    fHat2 = nfft(p, fApprox);
+    println("trafo")
+    toc()
 
-  N = 32
-  M = N*N*N
+    N = 32
+    M = N*N*N
 
-  x3 = rand(3,M) .- 0.5
-  fHat = rand(M)*1im
+    x3 = rand(3,M) .- 0.5
+    fHat = rand(M)*1im
 
-  println("NFFT Performance Test 3D")
+    println("NFFT Performance Test 3D")
 
-  tic()
-  p = NFFTPlan(x3,(N,N,N),m,sigma)
-  println("initialization")
-  toc()
+    tic()
+    p = NFFTPlan(x3,(N,N,N),m,sigma)
+    println("initialization")
+    toc()
 
-  tic()
-  fApprox = nfft_adjoint(p,fHat)
-  println("adjoint")
-  toc()
+    tic()
+    fApprox = nfft_adjoint(p,fHat)
+    println("adjoint")
+    toc()
 
-  tic()
-  fHat2 = nfft(p, fApprox);
-  println("trafo")
-  toc()
+    tic()
+    fHat2 = nfft(p, fApprox);
+    println("trafo")
+    toc()
 
 end
 

--- a/src/samplingDensity.jl
+++ b/src/samplingDensity.jl
@@ -1,27 +1,27 @@
 export sdc
 
 function sdc{D,T}(p::NFFTPlan{D,0,T}; iters=20)
-  # Weights for sample density compensation.
-  # Uses method of Pipe & Menon, 1999. Mag Reson Med, 186, 179.
-  weights = ones(Complex{T}, p.M)
-  weights_tmp = similar(weights)
-  # Pre-weighting to correct non-uniform sample density
-  for i in 1:iters
-    p.tmpVec[:] = 0.0
-    convolve_adjoint!(p, weights, p.tmpVec)
-    weights_tmp[:] = 0.0
-    convolve!(p, p.tmpVec, weights_tmp)
-    for j in 1:length(weights)
-      weights[j] = weights[j] / (abs(weights_tmp[j]) + eps(T))
+    # Weights for sample density compensation.
+    # Uses method of Pipe & Menon, 1999. Mag Reson Med, 186, 179.
+    weights = ones(Complex{T}, p.M)
+    weights_tmp = similar(weights)
+    # Pre-weighting to correct non-uniform sample density
+    for i in 1:iters
+        p.tmpVec[:] = 0.0
+        convolve_adjoint!(p, weights, p.tmpVec)
+        weights_tmp[:] = 0.0
+        convolve!(p, p.tmpVec, weights_tmp)
+        for j in 1:length(weights)
+            weights[j] = weights[j] / (abs(weights_tmp[j]) + eps(T))
+        end
     end
-  end
-  # Post weights to correct image scaling
-  # This finds c, where ||u - c*v||_2^2 = 0 and then uses
-  # c to scale all weights by a scalar factor.
-  u = ones(Complex{T}, p.N)
-  f = nfft(p, u)
-  f = f .* weights # apply weights from above
-  v = nfft_adjoint(p, f)
-  c = v[:] \ u[:]  # least squares diff
-  abs(weights * c[1]) # [1] needed b/c 'c' is a 1x1 Array
+    # Post weights to correct image scaling
+    # This finds c, where ||u - c*v||_2^2 = 0 and then uses
+    # c to scale all weights by a scalar factor.
+    u = ones(Complex{T}, p.N)
+    f = nfft(p, u)
+    f = f .* weights # apply weights from above
+    v = nfft_adjoint(p, f)
+    c = v[:] \ u[:]  # least squares diff
+    abs(weights * c[1]) # [1] needed b/c 'c' is a 1x1 Array
 end

--- a/src/windowFunctions.jl
+++ b/src/windowFunctions.jl
@@ -1,96 +1,96 @@
 if VERSION >= v"0.6.0-"
-  using SpecialFunctions
+    using SpecialFunctions
 end
 
 # This file contains different window functions.
 # The function getWindow returns a pair of window functions based on a string
 
 function getWindow(window::Symbol)
-  if window == :gauss
-    return window_gauss, window_gauss_hat
-  elseif window == :spline
-    return window_spline, window_spline_hat
-  elseif window == :kaiser_bessel_rev
-    return window_kaiser_bessel_rev, window_kaiser_bessel_rev_hat
-  else # default to kaiser_bessel
-    return window_kaiser_bessel, window_kaiser_bessel_hat
-  end
+    if window == :gauss
+        return window_gauss, window_gauss_hat
+    elseif window == :spline
+        return window_spline, window_spline_hat
+    elseif window == :kaiser_bessel_rev
+        return window_kaiser_bessel_rev, window_kaiser_bessel_rev_hat
+    else # default to kaiser_bessel
+        return window_kaiser_bessel, window_kaiser_bessel_hat
+    end
 end
 
 function window_kaiser_bessel(x,n,m,sigma)
-  b = pi*(2-1/sigma)
-  arg = m^2-n^2*x^2
-  if abs(x) < m/n
-    y = sinh(b*sqrt(arg))/sqrt(arg)/pi
-  elseif abs(x) > m/n
-    y = zero(x)
-  else
-    y = b/pi
-  end
-  return y
+    b = pi*(2-1/sigma)
+    arg = m^2-n^2*x^2
+    if abs(x) < m/n
+        y = sinh(b*sqrt(arg))/sqrt(arg)/pi
+    elseif abs(x) > m/n
+        y = zero(x)
+    else
+        y = b/pi
+    end
+    return y
 end
 
 function window_kaiser_bessel_hat(k,n,m,sigma)
-  b = pi*(2-1/sigma)
-  return besseli(0,m*sqrt(b^2-(2*pi*k/n)^2))
+    b = pi*(2-1/sigma)
+    return besseli(0,m*sqrt(b^2-(2*pi*k/n)^2))
 end
 
 function window_kaiser_bessel_rev(x,n,m,sigma)
-  b = pi*(2-1/sigma)
-  if abs(x) < m/n
-    arg = m*b*sqrt(1-(n*x/m)^2)
-    y = 0.5/m*besseli(0,arg)
-  else
-    y = zero(x)
-  end
-  return y
+    b = pi*(2-1/sigma)
+    if abs(x) < m/n
+        arg = m*b*sqrt(1-(n*x/m)^2)
+        y = 0.5/m*besseli(0,arg)
+    else
+        y = zero(x)
+    end
+    return y
 end
 
 function window_kaiser_bessel_rev_hat(k,n,m,sigma)
-  b = pi*(2-1/sigma)
+    b = pi*(2-1/sigma)
 
-  arg = sqrt(complex((2*pi*m*k/n)^2-(m*b)^2))
-  return sinc(arg/pi)
+    arg = sqrt(complex((2*pi*m*k/n)^2-(m*b)^2))
+    return sinc(arg/pi)
 end
 
 
 function window_gauss(x,n,m,sigma)
-  b = m / pi
-  if abs(x) < m/n
-    y = 1 / sqrt(pi*b) * exp(-(n*x)^2 / b)
-  else
-    y =  zero(x)
-  end
-  return y
+    b = m / pi
+    if abs(x) < m/n
+        y = 1 / sqrt(pi*b) * exp(-(n*x)^2 / b)
+    else
+        y =  zero(x)
+    end
+    return y
 end
 
 function window_gauss_hat(k,n,m,sigma)
-  b = m / pi
-  return exp(-(pi*k/(n))^2 * b)
+    b = m / pi
+    return exp(-(pi*k/(n))^2 * b)
 end
 
 function cbspline(m,x)
-  if m == 1
-    if x>=0 && x<1
-      y = one(x)
+    if m == 1
+        if x>=0 && x<1
+            y = one(x)
+        else
+            y = zero(x)
+        end
     else
-      y = zero(x)
+        y = x/(m-1)*cbspline(m-1,x) + (m-x)/(m-1)*cbspline(m-1,x-1)
     end
-  else
-    y = x/(m-1)*cbspline(m-1,x) + (m-x)/(m-1)*cbspline(m-1,x-1)
-  end
-  return y
+    return y
 end
 
 function window_spline(x,n,m,sigma)
-  if abs(x) < m/n
-    y = cbspline(2*m, n*x+m)
-  else
-    y = zero(x)
-  end
-  return y
+    if abs(x) < m/n
+        y = cbspline(2*m, n*x+m)
+    else
+        y = zero(x)
+    end
+    return y
 end
 
 function window_spline_hat(k,n,m,sigma)
-  return (sinc(k/n))^(2*m)
+    return (sinc(k/n))^(2*m)
 end


### PR DESCRIPTION
This is only a cosmetic change, no real change to the code (`git log -1 -p -b` shows no edit).

I know that sometimes this kind of changes are not welcome, but indentation in the package is rather inconsistent: sometimes tabs are used, sometimes 2 spaces, sometimes 4, sometimes more (sometimes none...).  This patch uses the style of [Julia itself](https://github.com/JuliaLang/julia/blob/5482f911c3d2f8c0dfd7102932cfece31fc4fd24/CONTRIBUTING.md#general-formatting-guidelines-for-julia-code-contributions) and [Julia Praxis](https://github.com/JuliaPraxis/Spacing/blob/53ff44cfebf043c7637b87de84218a4916c93ea2/guides/InlineSpacing.md):
* 4 spaces per indentation level, no tabs

There are also very long lines (in Julia hard wrapping after 92 characters is suggested), but I didn't touch them in order not to do code changes.