### PR TITLE
Broader compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 CUDA = "1.3.3, 2.3, 3.1"
-FFTW = "0.2, 1.0"
+FFTW = "0.2, 1"
 Graphics = "0.4, 1.0"
 SpecialFunctions = "0.8, 0.10, 1"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 CUDA = "1.3.3, 2.3, 3.1"
 FFTW = "0.2, 1.0"
 Graphics = "0.4, 1.0"
-SpecialFunctions = "0.8, 0.10, 1.0"
+SpecialFunctions = "0.8, 0.10, 1"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Small change to the compat section that currently prevents using CUDA.jl>=3 because it requires SpecialFunctions=1.3 