### PR TITLE
replace zeros with undef array in the constructor

### DIFF
--- a/src/CpuNFFT.jl
+++ b/src/CpuNFFT.jl
@@ -75,7 +75,7 @@ function NFFTPlan(x::Matrix{T}, N::NTuple{D,Int}, m=4, sigma=2.0,
 
     n = ntuple(d->round(Int,sigma*N[d]), D)
 
-    tmpVec = zeros(Complex{T}, n)
+    tmpVec = Array{Complex{T}}(undef, n)
 
     M = size(x,2)
 


### PR DESCRIPTION
Hi!
The constructor of the CPU-nFFT creates a rather large array tmpVec with the "zeros" method. To my understanding, this array is unsed in three different ways:
1) to plan the FFT, which should only need size of the array
2) in nfft!, where it is filled with zeros
3) in nfft_adjoint!, where it is written into. 

So to my understanding, we don't need to set this array to zero in the constructor. All tests pass with my modification on my computer--CI will tell us more. 

The benefit: For my use case (trj = rand(3, 72960) .- 0.5 and shape = (192,192,192)) is brings a speed-up of 500x. 

Thanks for considering!
Cheers,
Jakob