### PR TITLE
Fix loading of ChainRulesCore package extension for AbstractNFFTs

### DIFF
--- a/AbstractNFFTs/Project.toml
+++ b/AbstractNFFTs/Project.toml
@@ -16,3 +16,4 @@ AbstractNFFTsChainRulesCoreExt = "ChainRulesCore"
 
 [compat]
 julia = "1.6"
+ChainRulesCore = "1"

--- a/AbstractNFFTs/Project.toml
+++ b/AbstractNFFTs/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractNFFTs"
 uuid = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"
 author = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
The package extension for ChainRulesCore wasn't being properly loaded, probably because the Project.toml was missing a compat entry