### PR TITLE
Backend based AbstractNFFT implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           using Pkg
           Pkg.add(PackageSpec(path=pwd(), subdir="AbstractNFFTs"))
           Pkg.add(PackageSpec(path=pwd(), subdir="NFFTTools"))
-          Pkg.add(PackageSpec(path=pwd(), subdir="CuNFFT"))
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
@@ -70,7 +69,6 @@ jobs:
           using Pkg
           Pkg.add(PackageSpec(path=pwd(), subdir="AbstractNFFTs"))
           Pkg.add(PackageSpec(path=pwd(), subdir="NFFTTools"))
-          Pkg.add(PackageSpec(path=pwd(), subdir="CuNFFT"))
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/AbstractNFFTs/Project.toml
+++ b/AbstractNFFTs/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractNFFTs"
 uuid = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"
 author = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.8.3"
+version = "0.9.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/AbstractNFFTs/Project.toml
+++ b/AbstractNFFTs/Project.toml
@@ -7,6 +7,7 @@ version = "0.9.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -17,3 +18,4 @@ AbstractNFFTsChainRulesCoreExt = "ChainRulesCore"
 [compat]
 julia = "1.6"
 ChainRulesCore = "1"
+ScopedValues = "1"

--- a/AbstractNFFTs/src/AbstractNFFTs.jl
+++ b/AbstractNFFTs/src/AbstractNFFTs.jl
@@ -3,8 +3,16 @@ module AbstractNFFTs
 using LinearAlgebra
 using Printf
 
+# Remove this difference once 1.11 or higher becomes lower bound
+if VERSION >= v"1.11"
+  using Base.ScopedValues
+else
+  using ScopedValues
+end
+
+
 # interface
-export AbstractNFFTBackend
+export AbstractNFFTBackend, nfft_backend, with
 export AbstractFTPlan, AbstractRealFTPlan, AbstractComplexFTPlan,
        AbstractNFFTPlan, AbstractNFCTPlan, AbstractNFSTPlan, AbstractNNFFTPlan, 
        plan_nfft, plan_nfct, plan_nfst, mul!, size_in, size_out, nodes!
@@ -25,6 +33,7 @@ export TimingStats, accuracyParams, reltolToParams, paramsToReltol,
 include("misc.jl")
 include("interface.jl")
 include("derived.jl")
+
 
 @static if !isdefined(Base, :get_extension)
   import Requires

--- a/AbstractNFFTs/src/AbstractNFFTs.jl
+++ b/AbstractNFFTs/src/AbstractNFFTs.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using Printf
 
 # interface
+export AbstractNFFTBackend
 export AbstractFTPlan, AbstractRealFTPlan, AbstractComplexFTPlan,
        AbstractNFFTPlan, AbstractNFCTPlan, AbstractNFSTPlan, AbstractNNFFTPlan, 
        plan_nfft, plan_nfct, plan_nfst, mul!, size_in, size_out, nodes!

--- a/AbstractNFFTs/src/derived.jl
+++ b/AbstractNFFTs/src/derived.jl
@@ -46,19 +46,138 @@ plan_nnfft(::Missing, args...; kwargs...) = no_backend_error()
 # Allocating trafo functions with plan creation
 ###############################################
 
+"""
+    nfft(k, f, rest...; kwargs...)
+    nfft(backend, k, f, rest...; kwargs...)
+
+calculates the nfft of the array `f` for the nodes contained in the matrix `k`
+The output is a vector of length M=`size(nodes,2)`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+Backends can also be set with a scoped value overriding the current active backend within a scope:
+
+```julia
+julia> NFFT.activate!()
+
+julia> nfft(k, f, rest...; kwargs...) # uses NFFT
+
+julia> with(nfft_backend => NonuniformFFTs.backend()) do
+          nfft(k, f, rest...; kwargs...) # uses NonuniformFFTs
+       end
+```
+"""
+nfft
+"""
+    nfft_adjoint(k, N, fHat, rest...; kwargs...)
+    nfft_adjoint(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the adjoint nfft of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+Backends can also be set with a scoped value overriding the current active backend within a scope:
+
+```julia
+julia> NFFT.activate!()
+
+julia> nfft_adjoint(k, N, fHat, rest...; kwargs...) # uses NFFT
+
+julia> with(nfft_backend => NonuniformFFTs.backend()) do
+          nfft_adjoint(k, N, fHat, rest...; kwargs...) # uses NonuniformFFTs
+       end
+```
+"""
+nfft_adjoint
+"""
+    nfft_transpose(k, N, fHat, rest...; kwargs...)
+    nfft_transpose(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the transpose nfft of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+Backends can also be set with a scoped value overriding the current active backend within a scope:
+
+```julia
+julia> NFFT.activate!()
+
+julia> nfft_transpose(k, N, fHat, rest...; kwargs...) # uses NFFT
+
+julia> with(nfft_backend => NonuniformFFTs.backend()) do
+          nfft_transpose(k, N, fHat, rest...; kwargs...) # uses NonuniformFFTs
+       end
+```
+"""
+nfft_transpose
+
+"""
+    nfct(k, f, rest...; kwargs...)
+    nfct(backend, k, f, rest...; kwargs...)
+
+calculates the nfct of the array `f` for the nodes contained in the matrix `k`
+The output is a vector of length M=`size(nodes,2)`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfct
+"""
+    nfct_adjoint(k, N, fHat, rest...; kwargs...)
+    nfct_adjoint(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the adjoint nfct of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfct_adjoint
+"""
+    nfct_transpose(k, N, fHat, rest...; kwargs...)
+    nfct_transpose(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the transpose nfct of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfct_transpose
+
+"""
+    nfst(k, f, rest...; kwargs...)
+    nfst(backend, k, f, rest...; kwargs...)
+
+calculates the nfst of the array `f` for the nodes contained in the matrix `k`
+The output is a vector of length M=`size(nodes,2)`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfst
+"""
+    nfst_adjoint(k, N, fHat, rest...; kwargs...)
+    nfst_adjoint(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the adjoint nfst of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfst_adjoint
+"""
+    nfst_transpose(k, N, fHat, rest...; kwargs...)
+    nfst_transpose(backend, k, N, fHat, rest...; kwargs...)
+
+calculates the transpose nfst of the vector `fHat` for the nodes contained in the matrix `k`.
+The output is an array of size `N`.
+
+Uses the active AbstractNFFTs `backend` if no `backend` argument is provided. Backends can be activated with `BackendModule.activate!()`.
+"""
+nfst_transpose
+
 for (op,trans) in zip([:nfft, :nfct, :nfst],
                       [:adjoint, :transpose, :transpose])
 planfunc = Symbol("plan_$(op)")
 tfunc = Symbol("$(op)_$(trans)")
 @eval begin 
 
-# TODO fix comments (how?)
-"""
-nfft(backend, k, f, rest...; kwargs...)
-
-calculates the nfft of the array `f` for the nodes contained in the matrix `k`
-The output is a vector of length M=`size(nodes,2)`
-"""
 $(op)(k, f::AbstractArray; kargs...) = $(op)(active_backend(), k, f::AbstractArray; kargs...) 
 function $(op)(b::AbstractNFFTBackend, k, f::AbstractArray; kargs...) 
   p = $(planfunc)(k, size(f); kargs... )
@@ -67,12 +186,6 @@ end
 $(op)(::Missing, k, f::AbstractArray; kargs...) = no_backend_error()
 
 
-"""
-nfft_adjoint(backend, k, N, fHat, rest...; kwargs...)
-
-calculates the adjoint nfft of the vector `fHat` for the nodes contained in the matrix `k`.
-The output is an array of size `N`
-"""
 $(tfunc)(k, N, fHat;  kargs...) = $(tfunc)(active_backend(), k, N, fHat;  kargs...)
 function $(tfunc)(b::AbstractNFFTBackend, k, N, fHat;  kargs...) 
   p = $(planfunc)(k, N;  kargs...)

--- a/AbstractNFFTs/src/derived.jl
+++ b/AbstractNFFTs/src/derived.jl
@@ -10,29 +10,29 @@ planfunc = Symbol("plan_"*"$op")
 
 # The following automatically call the plan_* version for type Array
 
-$(planfunc)(k::AbstractArray, N::Union{Integer,NTuple{D,Int}}, args...; kargs...) where {D} =
-    $(planfunc)(Array, k, N, args...; kargs...)
+$(planfunc)(b::AbstractNFFTBackend, k::AbstractArray, N::Union{Integer,NTuple{D,Int}}, args...; kargs...) where {D} =
+    $(planfunc)(b, Array, k, N, args...; kargs...)
 
-$(planfunc)(k::AbstractArray, y::AbstractArray, args...; kargs...) =
-    $(planfunc)(Array, k, y, args...; kargs...)
+$(planfunc)(b::AbstractNFFTBackend, k::AbstractArray, y::AbstractArray, args...; kargs...) =
+    $(planfunc)(b, Array, k, y, args...; kargs...)
 
 # The follow convert 1D parameters into the format required by the plan
 
-$(planfunc)(Q::Type, k::AbstractVector, N::Integer, rest...; kwargs...)  =
-    $(planfunc)(Q, collect(reshape(k,1,length(k))), (N,), rest...; kwargs...)
+$(planfunc)(b::AbstractNFFTBackend, Q::Type, k::AbstractVector, N::Integer, rest...; kwargs...)  =
+    $(planfunc)(b, Q, collect(reshape(k,1,length(k))), (N,), rest...; kwargs...)
 
-$(planfunc)(Q::Type, k::AbstractVector, N::NTuple{D,Int}, rest...; kwargs...) where {D} =
-    $(planfunc)(Q, collect(reshape(k,1,length(k))), N, rest...; kwargs...) 
+$(planfunc)(b::AbstractNFFTBackend, Q::Type, k::AbstractVector, N::NTuple{D,Int}, rest...; kwargs...) where {D} =
+    $(planfunc)(b, Q, collect(reshape(k,1,length(k))), N, rest...; kwargs...) 
 
-$(planfunc)(Q::Type, k::AbstractMatrix, N::NTuple{D,Int}, rest...; kwargs...) where {D}  =
-    $(planfunc)(Q, collect(k), N, rest...; kwargs...)
+$(planfunc)(b::AbstractNFFTBackend, Q::Type, k::AbstractMatrix, N::NTuple{D,Int}, rest...; kwargs...) where {D}  =
+    $(planfunc)(b, Q, collect(k), N, rest...; kwargs...)
 
 end
 end
 
 ## NNFFT constructor
-plan_nnfft(Q::Type, k::AbstractVector, y::AbstractVector, rest...; kwargs...)  =
-    plan_nnfft(Q, collect(reshape(k,1,length(k))), collect(reshape(y,1,length(k))), rest...; kwargs...)
+plan_nnfft(b::AbstractNFFTBackend, Q::Type, k::AbstractVector, y::AbstractVector, rest...; kwargs...)  =
+    plan_nnfft(b, Q, collect(reshape(k,1,length(k))), collect(reshape(y,1,length(k))), rest...; kwargs...)
 
 
 
@@ -48,23 +48,23 @@ tfunc = Symbol("$(op)_$(trans)")
 
 # TODO fix comments (how?)
 """
-nfft(k, f, rest...; kwargs...)
+nfft(backend, k, f, rest...; kwargs...)
 
 calculates the nfft of the array `f` for the nodes contained in the matrix `k`
 The output is a vector of length M=`size(nodes,2)`
 """
-function $(op)(k, f::AbstractArray; kargs...) 
+function $(op)(b::AbstractNFFTBackend, k, f::AbstractArray; kargs...) 
   p = $(planfunc)(k, size(f); kargs... )
   return p * f
 end
 
 """
-nfft_adjoint(k, N, fHat, rest...; kwargs...)
+nfft_adjoint(backend, k, N, fHat, rest...; kwargs...)
 
 calculates the adjoint nfft of the vector `fHat` for the nodes contained in the matrix `k`.
 The output is an array of size `N`
 """
-function $(tfunc)(k, N, fHat;  kargs...) 
+function $(tfunc)(b::AbstractNFFTBackend, k, N, fHat;  kargs...) 
   p = $(planfunc)(k, N;  kargs...)
   return $(trans)(p) * fHat
 end

--- a/AbstractNFFTs/src/interface.jl
+++ b/AbstractNFFTs/src/interface.jl
@@ -1,3 +1,5 @@
+abstract type AbstractNFFTBackend end
+
 """
   AbstractFTPlan{T,D,R}
 

--- a/AbstractNFFTs/src/interface.jl
+++ b/AbstractNFFTs/src/interface.jl
@@ -1,4 +1,24 @@
 abstract type AbstractNFFTBackend end
+const ACTIVE_BACKEND = Ref{Union{Missing, AbstractNFFTBackend}}(missing)
+
+"""
+    set_active_backend!(back::Union{Missing, Module, AbstractNFFTBackend})
+
+Set the default NFFT plan backend. A module `back` must implement `back.backend()`.
+"""
+set_active_backend!(back::Module) = set_active_backend!(back.backend())
+function set_active_backend!(back::Union{Missing, AbstractNFFTBackend})
+  ACTIVE_BACKEND[] = back
+end
+active_backend() = ACTIVE_BACKEND[]
+function no_backend_error() 
+  error(
+    """
+    No default backend available!
+    Make sure to also "import/using" an NFFT backend such as NFFT or NonuniformFFTs.
+    """
+  )
+end
 
 """
   AbstractFTPlan{T,D,R}

--- a/NFFTTools/Project.toml
+++ b/NFFTTools/Project.toml
@@ -12,5 +12,5 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 [compat]
 julia = "1.6"
 AbstractFFTs = "1.0"
-AbstractNFFTs = "0.6, 0.7, 0.8"
+AbstractNFFTs = "0.6, 0.7, 0.8, 0.9"
 FFTW = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NFFT"
 uuid = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 authors = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.13.7"
+version = "0.14"
 
 [deps]
 AbstractNFFTs = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"
@@ -19,7 +19,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Adapt = "3, 4"
-AbstractNFFTs = "0.8"
+AbstractNFFTs = "0.9"
 BasicInterpolators = "0.6.5, 0.7"
 DataFrames = "1.3.1, 1.4.1"
 FFTW = "1.5"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 This package provides a Julia implementation of the Non-equidistant Fast Fourier Transform (NFFT).
-For a detailed introduction into the NFFT and its application please have a look at the [software paper](https://arxiv.org/pdf/2208.00049.pdf) on the `NFFT.jl`. Further resources are [nfft.org](http://www.nfft.org) and [finufft.readthedocs.io](https://finufft.readthedocs.io). You 
+For a detailed introduction into the NFFT and its application please have a look at the [software paper](https://arxiv.org/pdf/2208.00049.pdf) on the `NFFT.jl`. Further resources are [nfft.org](http://www.nfft.org) and [finufft.readthedocs.io](https://finufft.readthedocs.io).
 
 The NFFT is a fast implementation of the Non-equidistant Discrete Fourier Transform (NDFT) that is
 basically a Discrete Fourier Transform (DFT) with non-equidistant sampling nodes in either Fourier or time/space domain.
@@ -25,7 +25,7 @@ add NFFT
 ```
 This will install the packages `NFFT.jl` and all its dependencies. Most importantly it installs the abstract interface package `AbstractNFFTs.jl`, which `NFFT.jl` implements.
 
-Additional NFFT related tools can be obtained by adding the package `NFFTTools.jl`. If you need support for `CUDA` you also need to install the package `CuNFFT.jl`.
+Additional NFFT related tools can be obtained by adding the package `NFFTTools.jl`. If you need support for `CUDA` or other GPU backends, you only need to install the respective GPU backend and a GPU compatible plan will be available via a package extension.
 
 In case you want to use an alternative NFFT implementation such as [NFFT3.jl](https://github.com/NFFT/NFFT3.jl) or [FINUFFT.jl](https://github.com/ludvigak/FINUFFT.jl) we provide wrapper types allowing to use them as `AbstractNFFTs` implementations. They can be used like this:
 
@@ -34,7 +34,9 @@ julia> using AbstractNFFTs
 julia> include(joinpath(dirname(pathof(AbstractNFFTs)), "..", "..", "Wrappers", "FINUFFT.jl"))
 julia> include(joinpath(dirname(pathof(AbstractNFFTs)), "..", "..", "Wrappers", "NFFT3.jl"))
 ```
-This requires that you first `add` the package you want to use. 
+This requires that you first `add` the package you want to use.
+
+A related package is [NonuniformFFTs.jl](https://github.com/jipolanco/NonuniformFFTs.jl) which provides a pure Julia implementation using KernelAbstractions.jl. It also features an implementation of the `AbstractNFFTs.jl` interface.
 
 ## Guide
 

--- a/ext/NFFTGPUArraysExt/implementation.jl
+++ b/ext/NFFTGPUArraysExt/implementation.jl
@@ -16,7 +16,7 @@ mutable struct GPU_NFFTPlan{T,D, arrTc <: AbstractGPUArray{Complex{T}, D}, vecI 
   B::SM
 end
 
-function AbstractNFFTs.plan_nfft(arr::Type{<:AbstractGPUArray}, k::Matrix{T}, N::NTuple{D,Int}, rest...;
+function AbstractNFFTs.plan_nfft(::NFFTBackend, arr::Type{<:AbstractGPUArray}, k::Matrix{T}, N::NTuple{D,Int}, rest...;
   timing::Union{Nothing,TimingStats} = nothing, kargs...) where {T,D}
   t = @elapsed begin
     p = GPU_NFFTPlan(arr, k, N, rest...; kargs...)

--- a/src/NFFT.jl
+++ b/src/NFFT.jl
@@ -16,7 +16,7 @@ using BasicInterpolators
 
 @reexport using AbstractNFFTs
 
-export NDFTPlan, NDCTPlan, NDSTPlan, NNDFTPlan, 
+export NFFTBackend, NDFTPlan, NDCTPlan, NDSTPlan, NNDFTPlan, 
        NFFTPlan, NFFTParams
 
 
@@ -37,13 +37,14 @@ include("precomputation.jl")
 #################
 # factory methods
 #################
+struct NFFTBackend <: AbstractNFFTBackend end
 
 """
-        plan_nfft(k::Matrix{T}, N::NTuple{D,Int}, rest...;  kargs...)
+    NFFT.plan_nfft(k::Matrix{T}, N::NTuple{D,Int}, rest...;  kargs...)
 
 compute a plan for the NFFT of a size-`N` array at the nodes contained in `k`.
 """
-function AbstractNFFTs.plan_nfft(::Type{<:Array}, k::Matrix{T}, N::NTuple{D,Int}, rest...;
+function AbstractNFFTs.plan_nfft(::NFFTBackend, ::Type{<:Array}, k::Matrix{T}, N::NTuple{D,Int}, rest...;
                    timing::Union{Nothing,TimingStats} = nothing, kargs...) where {T,D}
   t = @elapsed begin
     p = NFFTPlan(k, N, rest...; kargs...)

--- a/src/NFFT.jl
+++ b/src/NFFT.jl
@@ -38,6 +38,8 @@ include("precomputation.jl")
 # factory methods
 #################
 struct NFFTBackend <: AbstractNFFTBackend end
+activate!() = AbstractNFFTs.set_active_backend!(NFFT)
+backend() = NFFTBackend()
 
 """
     NFFT.plan_nfft(k::Matrix{T}, N::NTuple{D,Int}, rest...;  kargs...)
@@ -61,6 +63,7 @@ include("convolution.jl")
 
 function __init__()
   NFFT._use_threads[] = (Threads.nthreads() > 1)
+  activate!()
 end
 
 include("precompile.jl")

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,7 +6,7 @@ using PrecompileTools
       J, N = 8, 16
       k = range(-0.4, stop=0.4, length=J)  # nodes at which the NFFT is evaluated
       f = randn(ComplexF64, J)             # data to be transformed
-      p = plan_nfft(k, N, reltol=1e-9)     # create plan
+      p = plan_nfft(NFFTBackend(), k, N, reltol=1e-9)     # create plan
       fHat = adjoint(p) * f                # calculate adjoint NFFT
       y = p * fHat                         # calculate forward NFFT
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -4,6 +4,10 @@
     @test NFFT.backend() isa NFFTBackend
     AbstractNFFTs.set_active_backend!(missing)
     @test ismissing(AbstractNFFTs.active_backend())
+    with(nfft_backend => NFFT.backend()) do
+      @test AbstractNFFTs.active_backend() isa NFFTBackend
+    end
+    @test ismissing(AbstractNFFTs.active_backend())
     NFFT.activate!()
     @test AbstractNFFTs.active_backend() isa NFFTBackend
   end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,5 +1,13 @@
 @testset "Constructors" begin
 
+  @testset "Backend" begin
+    @test NFFT.backend() isa NFFTBackend
+    AbstractNFFTs.set_active_backend!(missing)
+    @test ismissing(AbstractNFFTs.active_backend())
+    NFFT.activate!()
+    @test AbstractNFFTs.active_backend() isa NFFTBackend
+  end
+
   @test_throws ArgumentError NFFTPlan(zeros(1,4), (2,2))
 
   p = NFFTPlan(zeros(2,4), (2,2))


### PR DESCRIPTION
As discussed in [here](https://github.com/MagneticResonanceImaging/MRIReco.jl/issues/261), it is currently not possible to use the `plan_nfft` interface when multiple packages such as NFFT and NonuniformFFTs are loaded in the same session. The underlying issue is that both packages refer to the same function and usually have no dedicated type to dispatch one, as both want to dispatch on "normal" user array types.

This PR adds a "backend"-based selection of the NFFT plan implementation, which allows a user to chose which backend to use for a given `plan_nfft` call. This utilizes an additional first parameter which specifies the backend to use:

```julia
using AbstractNFFTs, NFFT, NonuniformFFTs
J, N = 8, 16
k = range(-0.4, stop=0.4, length=J)
plan_nfft(NFFT.backend(), k, N) # NFFT plan
plan_nfft(NonuniformFFTs.backend(), k, N) # Nonuniform plan
```

To hide this additional type from the users of upstream packages, AbstractNFFTs now features an active backend global constant, similar to how Makie allows one to switch between its backends:

```julia
using NFFT # internally calls NFFT.activate!()
J, N = 8, 16
k = range(-0.4, stop=0.4, length=J)
plan_nfft(k, N) # NFFT plan

using NonuniformFFTs
plan_nfft(k, N) # Nonuniform plan

NFFT.activate!()
plan_nfft(k, N) # NFFT plan again

with(nfft_backend => NonuniformFFTs.backend()) do
    plan_nfft(k, N) # Nonuniform plan but doesn't affect outer scope
end
```

This PR allows upstream packages such as [LinearOperatorCollection (PR)](https://github.com/JuliaImageRecon/LinearOperatorCollection.jl/pull/17) or MRIOperators to define themselves in terms of AbstractNFFTs and use exchangable NFFT providers.