### PR TITLE
Add docstring for convolve!

### DIFF
--- a/AbstractNFFTs/src/interface.jl
+++ b/AbstractNFFTs/src/interface.jl
@@ -219,27 +219,25 @@ Change nodes `k` in the plan `p` operation and return the plan.
 
 
 """
-   convolve!(p::AbstractNFFTPlan, g::AbstractArray, fHat::AbstractArray)
+   convolve!(p::AbstractNFFTPlan{T,D,R}, g::AbstractArray, fHat::AbstractArray)
 
-Overwrite vector `fHat`
-(of length `p.J`)
+Overwrite `R`-dimensional array `fHat`
+(often R=1, and `fHat` has length `p.J`)
 with the result of "convolution" (i.e., interpolation)
-between equispaced input array `g`
-(of size `p.N`)
+between `D`-dimensional equispaced input array `g`
+(often of size `p.N`)
 and the interpolation kernel in NFFT plan `p`.
 """
 @mustimplement convolve!(p::AbstractNFFTPlan, g::AbstractArray, fHat::AbstractArray)
 
 
 """
-    convolve_transpose!(p::AbstractNFFTPlan, fHat::AbstractArray, g::AbstractArray)
+    convolve_transpose!(p::AbstractNFFTPlan{T,D,R}, fHat::AbstractArray, g::AbstractArray)
 
 Adjoint of `convolve!` operation,
-where equispaced array `g`
-(of size `p.N`)
+where `D`-dimensional equispaced array `g`
 is overwritten
-based on the values of input vector `fHat`
-(of length `p.J`)
+based on the values of `R`-dimensional input array `fHat`
 and the interpolation kernel in NFFT plan `p`.
 """
 @mustimplement convolve_transpose!(p::AbstractNFFTPlan, fHat::AbstractArray, g::AbstractArray)

--- a/AbstractNFFTs/src/interface.jl
+++ b/AbstractNFFTs/src/interface.jl
@@ -216,8 +216,31 @@ Change nodes `k` in the plan `p` operation and return the plan.
 
 @mustimplement deconvolve!(p::AbstractNFFTPlan, f::AbstractArray, g::AbstractArray)
 @mustimplement deconvolve_transpose!(p::AbstractNFFTPlan, g::AbstractArray, f::AbstractArray)
+
+
+"""
+   convolve!(p::AbstractNFFTPlan, g::AbstractArray, fHat::AbstractArray)
+
+Overwrite vector `fHat`
+(of length `p.J`)
+with the result of "convolution" (i.e., interpolation)
+between equispaced input array `g`
+(of size `p.N`)
+and the interpolation kernel in NFFT plan `p`.
+"""
 @mustimplement convolve!(p::AbstractNFFTPlan, g::AbstractArray, fHat::AbstractArray)
+
+
+"""
+    convolve_transpose!(p::AbstractNFFTPlan, fHat::AbstractArray, g::AbstractArray)
+
+Adjoint of `convolve!` operation,
+where equispaced array `g`
+(of size `p.N`)
+is overwritten
+based on the values of input vector `fHat`
+(of length `p.J`)
+and the interpolation kernel in NFFT plan `p`.
+"""
 @mustimplement convolve_transpose!(p::AbstractNFFTPlan, fHat::AbstractArray, g::AbstractArray)
-
-
 


### PR DESCRIPTION
The absence of docstrings for key functions makes them hard to use for newcomers.
In particular it is crucial to know which input arguments are mutated.
This PR tries to address it.
