### PR TITLE
Allow `convolve` to work with `Real` arrays with arbitrary precision

### DIFF
--- a/AbstractNFFTs/src/interface.jl
+++ b/AbstractNFFTs/src/interface.jl
@@ -225,7 +225,7 @@ Overwrite `R`-dimensional array `fHat`
 (often R=1, and `fHat` has length `p.J`)
 with the result of "convolution" (i.e., interpolation)
 between `D`-dimensional equispaced input array `g`
-(often of size `p.N`)
+(often of size `p.Ñ`)
 and the interpolation kernel in NFFT plan `p`.
 """
 @mustimplement convolve!(p::AbstractNFFTPlan, g::AbstractArray, fHat::AbstractArray)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NFFT"
 uuid = "efe261a4-0d2b-5849-be55-fc731d526b0d"
-authors = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.14.1"
+authors = ["Tobias Knopp <tobias@knoppweb.de> and contributors"]
+version = "0.14.2"
 
 [deps]
 AbstractNFFTs = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -142,8 +142,8 @@ end
 
 function AbstractNFFTs.convolve_transpose!(
   ::NFFTPlan{<:Real,D,1},
-  ::StridedVector{<:Real},
-  ::AbstractArray{<:Complex, D},
+  ::AbstractVector{<:Complex},
+  ::StridedArray{<:Real, D},
 ) where {D}
   throw(ArgumentError("Complex input fHat requires Complex output g"))
 end

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -22,6 +22,10 @@ function AbstractNFFTs.convolve!(
   fHat::StridedVector{<:RealOrComplex}, # mutated
 ) where {D}
 
+  size(g) == p.Ñ ||
+    throw(DimensionMismatch("size(g)=$(size(g)) ≠ Ñ = $(p.Ñ)"))
+  size(fHat) == (p.J,) ||
+   throw(DimensionMismatch("size(fHat)=$(size(fHat)) ≠ J = $(p.J)"))
   (eltype(g) <: Complex) && (eltype(fHat) <: Real) &&
     throw(ArgumentError("Complex input g requires Complex output fHat"))
 
@@ -103,6 +107,10 @@ function AbstractNFFTs.convolve_transpose!(
   g::StridedArray{<:RealOrComplex, D}, # mutated
 ) where {D}
 
+  size(g) == p.Ñ ||
+    throw(DimensionMismatch("size(g)=$(size(g)) ≠ Ñ = $(p.Ñ)"))
+  size(fHat) == (p.J,) ||
+    throw(DimensionMismatch("size(fHat)=$(size(fHat)) ≠ J = $(p.J)"))
   (eltype(fHat) <: Complex) && (eltype(g) <: Real) &&
     throw(ArgumentError("Complex input fHat requires Complex output g"))
 

--- a/test/convolve.jl
+++ b/test/convolve.jl
@@ -1,0 +1,92 @@
+#=
+Test convolution (interpolation) and its adjoint in isolation
+
+One must be careful with Float16 output arrays here,
+because plan.windowLinInterp has values above 1e8
+that exceed the 6e4 maximum of Float16.
+
+FFTW does not support Float16 plans as of 2026-01-01.
+=#
+
+using NFFT: plan_nfft
+using AbstractNFFTs: convolve!, convolve_transpose!
+import NFFT # LINEAR, FULL, TENSOR, POLYNOMIAL
+using Test: @test, @testset
+
+# determine worst precision of two types
+function worst(T1::Type{<:Number}, T2::Type{<:Number})
+    return promote_type(T1, T2) == T1 ? T2 : T1
+end
+worst(a, b, c) = worst(worst(a, b), c)
+
+
+@testset "convolve!" begin
+
+  N = (9, 8) # 9×8 grid of equally spaced sampling points
+  Tb = BigFloat
+  fun = N -> @. Tb((0:(N-1)) / N - 0.5) # 1D grid
+  nodes = hcat([[x; y] for x in fun(N[1]), y in fun(N[2])]...)
+
+  T16 = Complex{Float16}
+  T32 = Complex{Float32}
+  T64 = Complex{Float64}
+  @test worst(T16, T64) == T16
+
+  J = prod(N) # for f
+  Ñ = 2 .* N # for g
+
+  for pre in [NFFT.LINEAR, NFFT.FULL, NFFT.TENSOR, NFFT.POLYNOMIAL]
+    p32 = plan_nfft(Float32.(nodes), N, m = 5, σ = 2.0, precompute=pre)
+    p64 = plan_nfft(Float64.(nodes), N, m = 5, σ = 2.0, precompute=pre)
+
+    @assert Ñ == p64.Ñ
+    f16 = Vector{T16}(undef, J)
+
+    g64 = rand(T64, Ñ)
+    g32 = T32.(g64)
+    g16 = T16.(g64)
+    @test g32 ≈ g64
+    @test g16 ≈ g64
+
+    fff = Vector{T64}(undef, J) # ground-truth reference
+    @test fff == convolve!(p64, g64, fff)
+
+    fmax = maximum(abs, fff) # need to avoid avoid overflow with T16
+
+    for Tg in (T16, T32, T64), Tf in (T32, T64)
+      f = Vector{Tf}(undef, J)
+      @test f == convolve!(p64, Tg.(g64), f)
+      T = worst(Tg, Tf)
+      @test f/fmax ≈ T.(fff/fmax)
+
+      @test f == convolve!(p32, Tg.(g64), f)
+      T = worst(Tg, Tf, T32)
+      @test f/fmax ≈ T.(fff/fmax)
+    end
+
+    # Float16 test with careful scaling:
+    @test f16 == convolve!(p64, g64/fmax, f16)
+    @test f16 ≈ fff/fmax
+    @test f16 == convolve!(p32, g64/fmax, f16)
+    @test f16 ≈ fff/fmax
+
+  end
+
+end # @testset
+
+#=
+
+  for pre in [NFFT.LINEAR, NFFT.FULL, NFFT.TENSOR, NFFT.POLYNOMIAL]
+@show pre
+    p = plan_nfft(nodes, N, m = 5, σ = 2.0, precompute=pre)
+
+    # ensure that convolve! works with mixed precisions
+    for Tf in (Float16, Float64), Tg in (Float16, Float64)
+        f = rand(Complex{Tf}, p.J)
+        g = rand(Complex{Tg}, p.N)
+        @test f == convolve!(p, g, f)
+        @test g == convolve_transpose!(p, g, f)
+    end
+  end
+=#
+

--- a/test/convolve.jl
+++ b/test/convolve.jl
@@ -11,82 +11,124 @@ FFTW does not support Float16 plans as of 2026-01-01.
 using NFFT: plan_nfft
 using AbstractNFFTs: convolve!, convolve_transpose!
 import NFFT # LINEAR, FULL, TENSOR, POLYNOMIAL
-using Test: @test, @testset
+using Test: @test, @testset, @test_throws
 
-# determine worst precision of two types
+# Determine worst precision of two types
+# (Does Julia already have such a method?)
 function worst(T1::Type{<:Number}, T2::Type{<:Number})
     return promote_type(T1, T2) == T1 ? T2 : T1
 end
 worst(a, b, c) = worst(worst(a, b), c)
 
 
+N = (9, 8) # 9×8 grid of equally spaced sampling points
+Tb = BigFloat
+fun = N -> @. Tb((0:(N-1)) / N - 0.5) # 1D grid
+nodes = hcat([[x; y] for x in fun(N[1]), y in fun(N[2])]...)
+
+F16 = Float16
+F32 = Float32
+F64 = Float64
+C16 = Complex{F16}
+C32 = Complex{F32}
+
+@testset "worst" begin
+  @test worst(F64, F16, F32) == F16
+  @test worst(C16, C32) == C16
+end
+
+J = prod(N) # for f
+Ñ = 2 .* N # for g
+
+@testset "convolve-throws" begin
+  # throw error when input is complex and output is real
+  p = plan_nfft(Float32.(nodes), N, m = 5, σ = 2.0, precompute=NFFT.LINEAR)
+  @test_throws ArgumentError convolve!(p, ones(C32, Ñ), zeros(Float32, J))
+  @test_throws ArgumentError convolve_transpose!(p, ones(C32, J), zeros(Float32,  Ñ))
+
+  # or when dimensions mismatch
+  @test_throws DimensionMismatch convolve!(p, ones(C32, Ñ), zeros(C32, 2))
+  @test_throws DimensionMismatch convolve!(p, ones(C32, N), zeros(C32, J))
+  @test_throws DimensionMismatch convolve_transpose!(p, ones(C32, 2), zeros(C32, Ñ))
+  @test_throws DimensionMismatch convolve_transpose!(p, ones(C32, J), zeros(C32, N))
+end
+
+
 @testset "convolve!" begin
-
-  N = (9, 8) # 9×8 grid of equally spaced sampling points
-  Tb = BigFloat
-  fun = N -> @. Tb((0:(N-1)) / N - 0.5) # 1D grid
-  nodes = hcat([[x; y] for x in fun(N[1]), y in fun(N[2])]...)
-
-  T16 = Complex{Float16}
-  T32 = Complex{Float32}
-  T64 = Complex{Float64}
-  @test worst(T16, T64) == T16
-
-  J = prod(N) # for f
-  Ñ = 2 .* N # for g
 
   for pre in [NFFT.LINEAR, NFFT.FULL, NFFT.TENSOR, NFFT.POLYNOMIAL]
     p32 = plan_nfft(Float32.(nodes), N, m = 5, σ = 2.0, precompute=pre)
     p64 = plan_nfft(Float64.(nodes), N, m = 5, σ = 2.0, precompute=pre)
-
     @assert Ñ == p64.Ñ
-    f16 = Vector{T16}(undef, J)
 
-    g64 = rand(T64, Ñ)
-    g32 = T32.(g64)
-    g16 = T16.(g64)
-    @test g32 ≈ g64
-    @test g16 ≈ g64
+    for tfun in (identity, t -> Complex{t}) # test both Real and Complex
+      T16 = tfun(F16)
+      T32 = tfun(F32)
+      T64 = tfun(F64)
 
-    fff = Vector{T64}(undef, J) # ground-truth reference
-    @test fff == convolve!(p64, g64, fff)
+      g64 = rand(T64, Ñ)
+      fff = Vector{T64}(undef, J) # ground-truth reference
+      @test fff == convolve!(p64, g64, fff)
 
-    fmax = maximum(abs, fff) # need to avoid avoid overflow with T16
+      fmax = maximum(abs, fff) # need to avoid avoid overflow with Float16
 
-    for Tg in (T16, T32, T64), Tf in (T32, T64)
-      f = Vector{Tf}(undef, J)
-      @test f == convolve!(p64, Tg.(g64), f)
-      T = worst(Tg, Tf)
-      @test f/fmax ≈ T.(fff/fmax)
+      for Tg in (T16, T32, T64), Tf in (T32, T64)
+        f = Vector{Tf}(undef, J)
+        @test f == convolve!(p64, Tg.(g64), f)
+        T = worst(Tg, Tf)
+        @test f/fmax ≈ T.(fff/fmax)
 
-      @test f == convolve!(p32, Tg.(g64), f)
-      T = worst(Tg, Tf, T32)
-      @test f/fmax ≈ T.(fff/fmax)
-    end
+        @test f == convolve!(p32, Tg.(g64), f)
+        T = worst(Tg, Tf, T32)
+        @test f / fmax ≈ T.(fff / fmax)
+      end
 
-    # Float16 test with careful scaling:
-    @test f16 == convolve!(p64, g64/fmax, f16)
-    @test f16 ≈ fff/fmax
-    @test f16 == convolve!(p32, g64/fmax, f16)
-    @test f16 ≈ fff/fmax
-
-  end
-
+      # Float16 test with careful scaling:
+      f16 = Vector{T16}(undef, J)
+      @test f16 == convolve!(p64, g64/fmax, f16)
+      @test f16 ≈ fff / fmax
+      @test f16 == convolve!(p32, g64/fmax, f16)
+      @test f16 ≈ fff / fmax
+    end # tfun
+  end # pre
 end # @testset
 
-#=
+
+@testset "convolve_transpose!" begin
 
   for pre in [NFFT.LINEAR, NFFT.FULL, NFFT.TENSOR, NFFT.POLYNOMIAL]
-@show pre
-    p = plan_nfft(nodes, N, m = 5, σ = 2.0, precompute=pre)
+    p32 = plan_nfft(Float32.(nodes), N, m = 5, σ = 2.0, precompute=pre)
+    p64 = plan_nfft(Float64.(nodes), N, m = 5, σ = 2.0, precompute=pre)
+    @assert Ñ == p64.Ñ
 
-    # ensure that convolve! works with mixed precisions
-    for Tf in (Float16, Float64), Tg in (Float16, Float64)
-        f = rand(Complex{Tf}, p.J)
-        g = rand(Complex{Tg}, p.N)
-        @test f == convolve!(p, g, f)
-        @test g == convolve_transpose!(p, g, f)
-    end
-  end
-=#
+    for tfun in (identity, t -> Complex{t}) # test both Real and Complex
+      T16 = tfun(F16)
+      T32 = tfun(F32)
+      T64 = tfun(F64)
 
+      f64 = rand(T64, J)
+      ggg = Array{T64}(undef, Ñ) # ground-truth reference
+      @test ggg == convolve_transpose!(p64, f64, ggg)
+
+      gmax = maximum(abs, ggg) # need to avoid avoid overflow with Float16
+
+      for Tg in (T32, T64), Tf in (T16, T32, T64)
+        g = similar(ggg, Tg)
+        @test g == convolve_transpose!(p64, Tf.(f64), g)
+        T = worst(Tg, Tf)
+        @test g / gmax ≈ T.(ggg / gmax)
+
+        @test g == convolve_transpose!(p32, Tf.(f64), g)
+        T = worst(Tg, Tf, T32)
+        @test g / gmax ≈ T.(ggg / gmax)
+      end
+
+      # Float16 test with careful scaling:
+      g16 = Array{T16}(undef, Ñ)
+      @test g16 == convolve_transpose!(p64, f64/gmax, g16)
+      @test g16 ≈ ggg / gmax
+      @test g16 == convolve_transpose!(p32, f64/gmax, g16)
+      @test g16 ≈ ggg / gmax
+    end # pre
+  end # tfun
+end # @testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ arrayTypes = areTypesDefined ? arrayTypes : [JLArray]
     include("issues.jl")
     include("accuracy.jl")
     include("constructors.jl")
+    include("convolve.jl")
     include("performance.jl")
     include("testToeplitz.jl")
     include("samplingDensity.jl")


### PR DESCRIPTION
Currently, `convolve!` and its adjoint are (partially) constrained to work with `Complex` vectors.
This constraint is natural for MRI reconstruction, but it is unnatural and inconvenient when designing sampling density compensation functions, because density factors should be `Real` (and positive).

This PR makes the following changes.  The first two are the big ones.
These are all backward-compatible.

- Use a `Union` to allow input arrays to be either `Real` or `Complex`.
- Allow the precision of the input arrays to differ from the precision of the Plan.
This generality should have no effect in the usual cases where the input array precisions match that of the `Plan`, while providing callers more flexibility if needed, with nearly negligible extra coding.  I'll note that the current version requires *one* of the two input arrays to have a precision that matches the plan, while the other input array uses "duck typing" with no precision constraints at all (in fact not even a constraint that the input array have `Number` elements).  This PR provides somewhat more equity in the element type freedom of the two input arrays.
Edit: the updated version removes the duck typing at the highest level of the interface and adds checks to make sure that a callee does not try to convolve a Complex input into a Real output. 
- Has `convolve!` and its adjoint return the mutated array, which is typical for mutating functions.
- Cleans up some trailing whitespace
- Consistently uses ` in ` instead of ` = ` with `for` loops; previous code used a mix of both styles.

If approved, I will ask for a version bump so I can use the new features to improve`sdc`.