### PR TITLE
Remove deprecated TagBot `lookback`

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,9 +4,6 @@ on:
     types:
       - created
   workflow_dispatch:
-    inputs:
-      lookback:
-        default: 3
 permissions:
   actions: read
   checks: read


### PR DESCRIPTION
TagBot `lookback` is deprecated:
https://github.com/JuliaRegistries/TagBot#lookback-period-deprecated